### PR TITLE
Dynamic host_label for traefik-conf

### DIFF
--- a/rancher/docker-compose.yml
+++ b/rancher/docker-compose.yml
@@ -21,7 +21,7 @@ traefik-conf:
   log_driver: ''
   labels:
     io.rancher.scheduler.global: 'true'
-    io.rancher.scheduler.affinity:host_label: traefik_lb=true
+    io.rancher.scheduler.affinity:host_label: ${host_label}
     io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
     io.rancher.container.start_once: 'true'
   tty: true


### PR DESCRIPTION
If the label for the main container [is dynamic](https://github.com/masone/alpine-traefik/blob/c984618f94a37b32fecfd48d2aa383bd42135590/rancher/docker-compose.yml#L9), it probably should be the same for it's sidekick.

Let me know if I'm getting this wrong :)