### PR TITLE
Fixed traefik.toml configuration file error

### DIFF
--- a/root/opt/traefik/bin/traefik.toml.sh
+++ b/root/opt/traefik/bin/traefik.toml.sh
@@ -2,7 +2,9 @@
 
 TRAEFIK_ENTRYPOINTS_HTTP="\
   [entryPoints.http]
-  address = \":${TRAEFIK_HTTP_PORT}\""
+  address = \":${TRAEFIK_HTTP_PORT}\"\
+
+"
 
 # Check that you provide key/crt files and add them to the config
 filelist=`ls -1 ${TRAEFIK_SSL_PATH}/*.key | cut -d"." -f1`


### PR DESCRIPTION
 Fixed traefik.toml configuration file error when using both http and https entrypoints (Issue #4)