### PR TITLE
Allow dot character in cert filenames

### DIFF
--- a/root/opt/traefik/bin/traefik.toml.sh
+++ b/root/opt/traefik/bin/traefik.toml.sh
@@ -30,7 +30,7 @@ TRAEFIK_ENTRYPOINTS_HTTP="\
   address = \":${TRAEFIK_HTTP_PORT}\"
 "
 
-filelist=`ls -1 ${TRAEFIK_SSL_PATH}/*.key | cut -d"." -f1`
+filelist=`ls -1 ${TRAEFIK_SSL_PATH}/*.key | rev | cut -d"." -f2- | rev`
 RC=`echo $?`
 
 if [ $RC -eq 0 ]; then


### PR DESCRIPTION
Many of my certs have filenames in the format `mydomain.com.crt` and I found that for now I have to rename them to `mydomain-com.crt` for alpine-traefik to find them. This change fixes that.