### PR TITLE
LetsEncrypt certificates and commercial ones should/can go side-by-side

### DIFF
--- a/root/opt/traefik/bin/traefik.toml.sh
+++ b/root/opt/traefik/bin/traefik.toml.sh
@@ -195,7 +195,7 @@ if [ "${TRAEFIK_HTTPS_ENABLE}" == "true" ] || [ "${TRAEFIK_HTTPS_ENABLE}" == "on
   filelist=`ls -1 ${TRAEFIK_SSL_PATH}/*.key | rev | cut -d"." -f2- | rev`
   RC=`echo $?`
 
-  if [ $RC -eq 0 ] && [ "${TRAEFIK_ACME_ENABLE}" == "false" ]; then
+  if [ $RC -eq 0 ]; then
       for i in $filelist; do
           if [ -f "$i.crt" ]; then
               TRAEFIK_ENTRYPOINTS_HTTPS=$TRAEFIK_ENTRYPOINTS_HTTPS"


### PR DESCRIPTION
Is there a reason that LE and commercial certificates are mutually exclusive? - if not, this PR allows both.