### PR TITLE
fix multiline strings in TRAEFIK_ADMIN_AUTH_USERS

### DIFF
--- a/root/opt/traefik/bin/traefik.toml.sh
+++ b/root/opt/traefik/bin/traefik.toml.sh
@@ -215,7 +215,7 @@ if [ "${TRAEFIK_ADMIN_ENABLE}" == "true" ]; then
     compress = ${TRAEFIK_HTTP_COMPRESSION}
 "
     if [ "${TRAEFIK_ADMIN_AUTH_USERS}" != "" ]; then
-        echo ${TRAEFIK_ADMIN_AUTH_USERS} > "${SERVICE_HOME}/.htpasswd"
+        echo "${TRAEFIK_ADMIN_AUTH_USERS}" > "${SERVICE_HOME}/.htpasswd"
         TRAEFIK_ENTRYPOINTS_ADMIN=${TRAEFIK_ENTRYPOINTS_ADMIN}"\
     [entryPoints.traefik.auth.${TRAEFIK_ADMIN_AUTH_METHOD}]
       usersFile = \"${SERVICE_HOME}/.htpasswd\"


### PR DESCRIPTION
The newlines are ignored if the `echo` command is done without the quotation marks.
With this fix is possible to use multiple users because in `./htpasswd` there is one line for each user.
![bash_newline](https://user-images.githubusercontent.com/12937873/47211750-9b5e3e00-d396-11e8-9cc1-5c4a3b2fcb6c.png)
