### PR TITLE
Output service log to stderr

### DIFF
--- a/root/opt/traefik/bin/traefik-service.sh
+++ b/root/opt/traefik/bin/traefik-service.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function log {
-        echo `date` $ME - $@
+    echo `date` $ME - $@ > /proc/1/fd/2
 }
 
 function serviceLog {
@@ -9,7 +9,7 @@ function serviceLog {
     if [ -e ${TRAEFIK_LOG_FILE} ]; then
         rm ${TRAEFIK_LOG_FILE}
     fi
-    ln -sf /proc/1/fd/1 ${TRAEFIK_LOG_FILE}
+    ln -sf /proc/1/fd/2 ${TRAEFIK_LOG_FILE}
 }
 
 function serviceAccess {
@@ -51,13 +51,13 @@ export TRAEFIK_ACCESS_FILE=${TRAEFIK_ACCESS_FILE:-"${SERVICE_HOME}/log/access.lo
 
 case "$1" in
         "start")
-            serviceStart &>> /proc/1/fd/1
+            serviceStart &>> /proc/1/fd/2
         ;;
         "stop")
-            serviceStop &>> /proc/1/fd/1
+            serviceStop &>> /proc/1/fd/2
         ;;
         "restart")
-            serviceRestart &>> /proc/1/fd/1
+            serviceRestart &>> /proc/1/fd/2
         ;;
         *) echo "Usage: $0 restart|start|stop"
         ;;


### PR DESCRIPTION
Because the accesslog can make the (error, startup, acme) output of traefik disappear quickly, move the output to stderr and leave the stdout almost to the accesslog.